### PR TITLE
Bibindex:  Native Fulltext index Textify  Doc

### DIFF
--- a/modules/bibindex/lib/tokenizers/BibIndexFulltextTokenizer.py
+++ b/modules/bibindex/lib/tokenizers/BibIndexFulltextTokenizer.py
@@ -120,6 +120,8 @@ class BibIndexFulltextTokenizer(BibIndexDefaultTokenizer):
                 else:
                     text = ""
                     if hasattr(bibdoc, "get_text"):
+                        #Textify doc before getting 
++                       bibdoc.extract_text()
                         text = bibdoc.get_text()
                     return self.tokenize_for_words_default(text)
             else:


### PR DESCRIPTION
BibIndex: native fulltext index textification
 
* FIX Enables native fulltext indexing by explicitly extracting text when using the BibDoc
  interface. (closes #3708) (closes #3690), (closes #2576)